### PR TITLE
Fix Diffuser not replacing values properly

### DIFF
--- a/HTTP/src/main/java/com/hawolt/http/Diffuser.java
+++ b/HTTP/src/main/java/com/hawolt/http/Diffuser.java
@@ -18,7 +18,7 @@ public class Diffuser {
 
     public static String vaporize(String tarnished) {
         for (String key : new ArrayList<>(set)) {
-            if (tarnished.contains(key)) tarnished = tarnished.replaceAll(key, "\\$\\{REDACTED_USER_CRITICAL_VALUE\\}");
+            if (tarnished.contains(key)) tarnished = tarnished.replace(key, "\\${REDACTED_USER_CRITICAL_VALUE}");
         }
         return tarnished;
     }


### PR DESCRIPTION
According to the [documentation](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/String.html#replace(java.lang.CharSequence,java.lang.CharSequence)), `replaceAll` treats the first string as regex instead of a literal value, while `replace` replaces all literal occurences of the first string.

So using `replace` instead of `replaceAll` here is correct and prevents the replacement failing when `key` contains special regex characters.